### PR TITLE
fix: handle relative URLs in database handlers

### DIFF
--- a/docs/content/docs/8.advanced/9.private.md
+++ b/docs/content/docs/8.advanced/9.private.md
@@ -88,7 +88,7 @@ You must protect the **key endpoint** so only authenticated users receive decryp
 import { eventHandler, createError } from 'h3'
 
 export default eventHandler(async (event) => {
-  const url = new URL(event.node.req.url || 'http://localhost')
+  const url = new URL(event.node.req.url || '', 'http://localhost')
   if (!url.pathname.endsWith('/key')) return
 
   // Example check: replace with your own session/JWT/CF Access logic

--- a/src/runtime/presets/cloudflare/database-handler.ts
+++ b/src/runtime/presets/cloudflare/database-handler.ts
@@ -4,7 +4,8 @@ import { deriveContentKeyB64, encryptGzBase64Envelope } from '../../internal/enc
 
 export default eventHandler(async (event) => {
   const collection = getRouterParam(event, 'collection')!
-  const url = new URL(event.node.req.url || 'http://localhost')
+  // `event.node.req.url` may be relative; supply a base URL to avoid runtime errors.
+  const url = new URL(event.node.req.url || '', 'http://localhost')
   const runtime = useRuntimeConfig()
   const encEnabled = !!runtime?.content?.encryption?.enabled
   const masterB64 = runtime?.content?.encryption?.masterKey

--- a/src/runtime/presets/node/database-handler.ts
+++ b/src/runtime/presets/node/database-handler.ts
@@ -4,7 +4,9 @@ import { deriveContentKeyB64, encryptGzBase64Envelope } from '../../internal/enc
 
 export default eventHandler(async (event) => {
   const collection = getRouterParam(event, 'collection')!
-  const url = new URL(event.node.req.url || 'http://localhost')
+  // `event.node.req.url` can be a relative path, which causes `new URL` to throw.
+  // Provide a base to ensure a valid absolute URL is always created.
+  const url = new URL(event.node.req.url || '', 'http://localhost')
 
   const runtime = useRuntimeConfig()
   const encEnabled = !!runtime?.content?.encryption?.enabled


### PR DESCRIPTION
## Summary
- avoid `new URL` errors by adding base URL in node and cloudflare database handlers
- update docs example to reflect new URL parsing

## Testing
- `pnpm lint`
- `pnpm dev:prepare`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4bd082a1c8324bbdfc36e9ed5c767