### PR TITLE
fix(security): handle escaped trailing quotes in cleanupQuery

### DIFF
--- a/src/runtime/internal/security.ts
+++ b/src/runtime/internal/security.ts
@@ -88,7 +88,6 @@ function cleanupQuery(query: string, options: { removeString: boolean } = { remo
   let result = ''
   for (let i = 0; i < query.length; i++) {
     const char = query[i]
-    const prevChar = query[i - 1]
     const nextChar = query[i + 1]
 
     if (char === '\'' || char === '"') {
@@ -98,8 +97,14 @@ function cleanupQuery(query: string, options: { removeString: boolean } = { remo
       }
 
       if (inString) {
-        if (char !== stringFence || nextChar === stringFence || prevChar === stringFence) {
+        if (char !== stringFence) {
           // skip character, it's part of a string
+          continue
+        }
+
+        if (nextChar === stringFence) {
+          // escaped quote inside a string literal
+          i++
           continue
         }
 

--- a/test/unit/assertSafeQuery.test.ts
+++ b/test/unit/assertSafeQuery.test.ts
@@ -44,7 +44,9 @@ describe('decompressSQLDump', () => {
     'SELECT * FROM _content_test WHERE (1=\' \\\' OR id IN (SELECT id FROM _content_docs) OR 1!=\'\') ORDER BY id ASC': false,
     'SELECT "id", "id" FROM _content_docs WHERE (1=\' \\\') UNION SELECT tbl_name,tbl_name FROM sqlite_master-- \') ORDER BY id ASC': false,
     'SELECT "id" FROM _content_test WHERE (x=$\'$ OR x IN (SELECT BLAH) OR x=$\'$) ORDER BY id ASC': false,
+    'SELECT * FROM _content_test WHERE (id = \'abc\'\'def\') ORDER BY id ASC': true,
     'SELECT * FROM _content_test WHERE (1=\'abc\'\'\' UNION SELECT name FROM sqlite_master) ORDER BY id ASC': false,
+    'SELECT * FROM _content_test WHERE (1="abc""" UNION SELECT name FROM sqlite_master) ORDER BY id ASC': false,
   }
 
   Object.entries(queries).forEach(([query, isValid]) => {

--- a/test/unit/assertSafeQuery.test.ts
+++ b/test/unit/assertSafeQuery.test.ts
@@ -44,6 +44,7 @@ describe('decompressSQLDump', () => {
     'SELECT * FROM _content_test WHERE (1=\' \\\' OR id IN (SELECT id FROM _content_docs) OR 1!=\'\') ORDER BY id ASC': false,
     'SELECT "id", "id" FROM _content_docs WHERE (1=\' \\\') UNION SELECT tbl_name,tbl_name FROM sqlite_master-- \') ORDER BY id ASC': false,
     'SELECT "id" FROM _content_test WHERE (x=$\'$ OR x IN (SELECT BLAH) OR x=$\'$) ORDER BY id ASC': false,
+    'SELECT * FROM _content_test WHERE (1=\'abc\'\'\' UNION SELECT name FROM sqlite_master) ORDER BY id ASC': false,
   }
 
   Object.entries(queries).forEach(([query, isValid]) => {


### PR DESCRIPTION
### Motivation

- `assertSafeQuery` strips string literals via `cleanupQuery(..., { removeString: true })` before checking for disallowed SQL commands, and a bug in `cleanupQuery` could leave `inString` true for the remainder of a `WHERE` clause so injected `UNION SELECT` sequences are hidden. 
- The goal is to ensure quoted string parsing closes correctly, including cases with adjacent/escaped quotes, so the SQL command detection remains reliable.

### Description

- Update `cleanupQuery` (`src/runtime/internal/security.ts`) to stop using the previous-character heuristic and instead treat adjacent doubled fence characters (`''` or `""`) as escaped quotes while correctly advancing the scan index. 
- Ensure the string literal is closed when a fence quote is encountered and not escaped, preventing `inString` from remaining set and removing the rest of the clause from inspection. 
- Add a regression test in `test/unit/assertSafeQuery.test.ts` that covers the reported payload pattern containing a trailing escaped quote followed by `UNION SELECT` to prevent regressions.

### Testing

- Ran `pnpm nuxt prepare` to generate project types which was required for the test environment and completed successfully. 
- Ran `pnpm vitest run test/unit/assertSafeQuery.test.ts`; the first `vitest` run failed due to a missing generated `./.nuxt/tsconfig.json`, then after `pnpm nuxt prepare` the test run completed successfully. 
- Final test results: `test/unit/assertSafeQuery.test.ts` passed (27 tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d85f2d96d48324bb191b5edf9b6bce)