### PR TITLE
fix(security): restore content query/dump endpoints to /api namespace

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -175,11 +175,17 @@ export default defineNuxtModule<ModuleOptions>({
 
     // @ts-expect-error - Prevent nuxtseo from indexing nuxt-content routes
     // @see https://github.com/nuxt/content/pull/3299
-    nuxt.options.routeRules![`/api/content/**`] = { robots: false }
+    nuxt.options.routeRules![`/api/content/**`] = {
+      ...nuxt.options.routeRules![`/api/content/**`],
+      robots: false,
+    }
 
     manifest.collections.forEach((collection) => {
       if (!collection.private) {
-        nuxt.options.routeRules![`/api/content/${collection.name}/sql_dump.txt`] = { prerender: true }
+        nuxt.options.routeRules![`/api/content/${collection.name}/sql_dump.txt`] = {
+          ...nuxt.options.routeRules![`/api/content/${collection.name}/sql_dump.txt`],
+          prerender: true,
+        }
       }
     })
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -175,11 +175,11 @@ export default defineNuxtModule<ModuleOptions>({
 
     // @ts-expect-error - Prevent nuxtseo from indexing nuxt-content routes
     // @see https://github.com/nuxt/content/pull/3299
-    nuxt.options.routeRules![`/__nuxt_content/**`] = { robots: false }
+    nuxt.options.routeRules![`/api/content/**`] = { robots: false }
 
     manifest.collections.forEach((collection) => {
       if (!collection.private) {
-        nuxt.options.routeRules![`/__nuxt_content/${collection.name}/sql_dump.txt`] = { prerender: true }
+        nuxt.options.routeRules![`/api/content/${collection.name}/sql_dump.txt`] = { prerender: true }
       }
     })
 
@@ -194,7 +194,7 @@ export default defineNuxtModule<ModuleOptions>({
 
       config.handlers ||= []
       config.handlers.push({
-        route: '/__nuxt_content/:collection/query',
+        route: '/api/content/:collection/query',
         handler: resolver.resolve('./runtime/api/query.post'),
       })
 

--- a/src/presets/aws-amplify.ts
+++ b/src/presets/aws-amplify.ts
@@ -12,7 +12,7 @@ export default definePreset({
     // Fetching assets on server side is not working with AWS Amplify
     // Disable prerendering to avoid fetching assets on server side
     Object.keys(nuxt.options.routeRules || {}).forEach((route) => {
-      if (route.startsWith('/__nuxt_content/') && route.endsWith('/sql_dump.txt')) {
+      if (route.startsWith('/api/content/') && route.endsWith('/sql_dump.txt')) {
         nuxt.options.routeRules![route]!.prerender = false
       }
     })

--- a/src/presets/cloudflare.ts
+++ b/src/presets/cloudflare.ts
@@ -26,7 +26,7 @@ export default definePreset({
     // Add raw content dump to public assets
     nitroConfig.publicAssets.push({ dir: join(nitroConfig.buildDir!, 'content', 'raw'), maxAge: 60 })
     nitroConfig.handlers.push({
-      route: '/__nuxt_content/:collection/sql_dump.txt',
+      route: '/api/content/:collection/sql_dump.txt',
       handler: resolver.resolve('./runtime/presets/cloudflare/database-handler'),
     })
   },

--- a/src/presets/node.ts
+++ b/src/presets/node.ts
@@ -11,7 +11,7 @@ export default definePreset({
 
     nitroConfig.alias['#content/dump'] = addTemplate(fullDatabaseCompressedDumpTemplate(manifest)).dst
     nitroConfig.handlers.push({
-      route: '/__nuxt_content/:collection/sql_dump.txt',
+      route: '/api/content/:collection/sql_dump.txt',
       handler: resolver.resolve('./runtime/presets/node/database-handler'),
     })
   },

--- a/src/runtime/internal/api.ts
+++ b/src/runtime/internal/api.ts
@@ -2,7 +2,7 @@ import type { H3Event } from 'h3'
 import { checksums } from '#content/manifest'
 
 export async function fetchDatabase(event: H3Event | undefined, collection: string): Promise<string> {
-  return await $fetch(`/__nuxt_content/${collection}/sql_dump.txt`, {
+  return await $fetch(`/api/content/${collection}/sql_dump.txt`, {
     context: event ? { cloudflare: event.context.cloudflare } : {},
     responseType: 'text',
     headers: {
@@ -14,7 +14,7 @@ export async function fetchDatabase(event: H3Event | undefined, collection: stri
 }
 
 export async function fetchQuery<Item>(event: H3Event | undefined, collection: string, sql: string): Promise<Item[]> {
-  return await $fetch(`/__nuxt_content/${collection}/query`, {
+  return await $fetch(`/api/content/${collection}/query`, {
     context: event ? { cloudflare: event.context.cloudflare } : {},
     headers: {
       'content-type': 'application/json',

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -88,7 +88,7 @@ describe('basic', async () => {
     })
 
     test('is downloadable', async () => {
-      const response: string = await $fetch('/__nuxt_content/content/sql_dump.txt', { responseType: 'text' })
+      const response: string = await $fetch('/api/content/content/sql_dump.txt', { responseType: 'text' })
       expect(response).toBeDefined()
 
       const parsedDump = await decompressSQLDump(response as string)

--- a/test/empty.test.ts
+++ b/test/empty.test.ts
@@ -90,7 +90,7 @@ describe('empty', async () => {
     })
 
     test('is downloadable', async () => {
-      const response: string = await $fetch('/__nuxt_content/content/sql_dump.txt', { responseType: 'text' })
+      const response: string = await $fetch('/api/content/content/sql_dump.txt', { responseType: 'text' })
       expect(response).toBeDefined()
 
       const parsedDump = await decompressSQLDump(response)


### PR DESCRIPTION
### Motivation

- A recent change registered the content query and SQL dump endpoints under `/__nuxt_content/*`, which can bypass deployments that apply auth/security middleware only to `/api/*`, exposing private collection data.

### Description

- Re-registers the runtime query endpoint under `'/api/content/:collection/query'` in the module Nitro config by updating `src/module.ts`.
- Restores SQL dump handler routes to `'/api/content/:collection/sql_dump.txt'` in the Node and Cloudflare presets by updating `src/presets/node.ts` and `src/presets/cloudflare.ts`, and aligns AWS Amplify prerender logic in `src/presets/aws-amplify.ts` to the `'/api/content/*'` pattern.
- Updates internal client/server helpers to call the `'/api/content/*'` endpoints in `src/runtime/internal/api.ts` and adjusts test expectations in `test/basic.test.ts` and `test/empty.test.ts` to match the hardened routes.

### Testing

- Attempted to run the targeted Vitest suite with `pnpm -s vitest run test/unit/collectionQueryBuilder.test.ts`, but the run failed in this environment due to a missing generated Nuxt tsconfig (`./.nuxt/tsconfig.json`), so automated tests could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d89fb2c1b48324b73c84e87b9e8a1b)