### PR TITLE
fix(security): reject non-string sql before query cleanup

### DIFF
--- a/src/runtime/internal/security.ts
+++ b/src/runtime/internal/security.ts
@@ -12,7 +12,7 @@ const SQL_SELECT_REGEX = /^SELECT (.*) FROM (\w+)( WHERE .*)? ORDER BY (["\w,\s]
  * @returns True if the query is safe, false otherwise
  */
 export function assertSafeQuery(sql: string, collection: string) {
-  if (!sql) {
+  if (typeof sql !== 'string' || !sql) {
     throw new Error('Invalid query: Query cannot be empty')
   }
 

--- a/test/unit/assertSafeQuery.test.ts
+++ b/test/unit/assertSafeQuery.test.ts
@@ -57,6 +57,10 @@ describe('decompressSQLDump', () => {
     })
   })
 
+  it('rejects non-string SQL input', () => {
+    expect(() => assertSafeQuery({ length: 1000000000 } as never, 'test')).toThrow()
+  })
+
   it('all queries should be valid', async () => {
     await collectionQueryBuilder(mockCollection, mockFetch).all()
     expect(() => assertSafeQuery(mockFetch.mock.lastCall![1], mockCollection)).not.toThrow()


### PR DESCRIPTION
### Motivation
- Prevent an unauthenticated DoS where a non-string `sql` payload (e.g. `{ "sql": { length: 1000000000 } }`) reaches `cleanupQuery` and triggers a length-controlled expensive loop and memory growth.

### Description
- Add a runtime type guard to `assertSafeQuery` to throw when `sql` is not a `string` or is empty, in `src/runtime/internal/security.ts` (`if (typeof sql !== 'string' || !sql)`).
- Add a unit test `test/unit/assertSafeQuery.test.ts` that asserts object-shaped/non-string `sql` inputs are rejected.

### Testing
- Added `test/unit/assertSafeQuery.test.ts` which includes the non-string input check and was committed.
- Ran `pnpm -s vitest run test/unit/assertSafeQuery.test.ts` in this environment and it failed due to a missing `./.nuxt/tsconfig.json` (Nuxt prepare/build step not executed), so the test suite could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8a398f6f88324a0b0a4ae0c492ecb)