### PR TITLE
fix: harden query builder against SQL injection via field/operator inputs

### DIFF
--- a/src/runtime/internal/query.ts
+++ b/src/runtime/internal/query.ts
@@ -2,6 +2,22 @@ import { withoutTrailingSlash } from 'ufo'
 import type { Collections, CollectionQueryBuilder, CollectionQueryGroup, QueryGroupFunction, SQLOperator } from '@nuxt/content'
 import { tables } from '#content/manifest'
 
+const SQL_OPERATORS = new Set<SQLOperator>([
+  '=',
+  '>=',
+  '<=',
+  '>',
+  '<',
+  '<>',
+  'IN',
+  'BETWEEN',
+  'NOT BETWEEN',
+  'IS NULL',
+  'IS NOT NULL',
+  'LIKE',
+  'NOT LIKE',
+])
+
 const buildGroup = <T extends keyof Collections>(group: CollectionQueryGroup<Collections[T]>, type: 'AND' | 'OR') => {
   const conditions = (group as unknown as { _conditions: Array<string> })._conditions
   return conditions.length > 0 ? `(${conditions.join(` ${type} `)})` : ''
@@ -14,14 +30,16 @@ export const collectionQueryGroup = <T extends keyof Collections>(collection: T)
     // @ts-expect-error -- internal
     _conditions: conditions,
     where(field: keyof Collections[T] | string, operator: SQLOperator, value?: unknown): CollectionQueryGroup<Collections[T]> {
+      const safeField = quoteIdentifier(field, 'where')
+      const safeOperator = toSafeOperator(operator)
       let condition: string
 
-      switch (operator.toUpperCase()) {
+      switch (safeOperator) {
         case 'IN':
         case 'NOT IN':
           if (Array.isArray(value)) {
             const values = value.map(val => singleQuote(val)).join(', ')
-            condition = `"${String(field)}" ${operator.toUpperCase()} (${values})`
+            condition = `${safeField} ${safeOperator} (${values})`
           }
           else {
             throw new TypeError(`Value for ${operator} must be an array`)
@@ -31,7 +49,7 @@ export const collectionQueryGroup = <T extends keyof Collections>(collection: T)
         case 'BETWEEN':
         case 'NOT BETWEEN':
           if (Array.isArray(value) && value.length === 2) {
-            condition = `"${String(field)}" ${operator.toUpperCase()} ${singleQuote(value[0])} AND ${singleQuote(value[1])}`
+            condition = `${safeField} ${safeOperator} ${singleQuote(value[0])} AND ${singleQuote(value[1])}`
           }
           else {
             throw new Error(`Value for ${operator} must be an array with two elements`)
@@ -40,16 +58,16 @@ export const collectionQueryGroup = <T extends keyof Collections>(collection: T)
 
         case 'IS NULL':
         case 'IS NOT NULL':
-          condition = `"${String(field)}" ${operator.toUpperCase()}`
+          condition = `${safeField} ${safeOperator}`
           break
 
         case 'LIKE':
         case 'NOT LIKE':
-          condition = `"${String(field)}" ${operator.toUpperCase()} ${singleQuote(value)}`
+          condition = `${safeField} ${safeOperator} ${singleQuote(value)}`
           break
 
         default:
-          condition = `"${String(field)}" ${operator} ${singleQuote(typeof value === 'boolean' ? Number(value) : value)}`
+          condition = `${safeField} ${safeOperator} ${singleQuote(typeof value === 'boolean' ? Number(value) : value)}`
       }
       conditions.push(`${condition}`)
       return query
@@ -118,7 +136,8 @@ export const collectionQueryBuilder = <T extends keyof Collections>(collection: 
       return query
     },
     order(field: keyof Collections[T], direction: 'ASC' | 'DESC') {
-      params.orderBy.push(`"${String(field)}" ${direction}`)
+      const safeDirection = direction === 'DESC' ? 'DESC' : 'ASC'
+      params.orderBy.push(`${quoteIdentifier(field, 'order')} ${safeDirection}`)
       return query
     },
     async all(): Promise<Collections[T][]> {
@@ -129,7 +148,7 @@ export const collectionQueryBuilder = <T extends keyof Collections>(collection: 
     },
     async count(field: keyof Collections[T] | '*' = '*', distinct: boolean = false) {
       return fetch(collection, buildQuery({
-        count: { field: String(field), distinct },
+        count: { field: field === '*' ? field : unquoteIdentifier(quoteIdentifier(field, 'count')), distinct },
       })).then(m => (m[0] as { count: number }).count)
     },
   }
@@ -174,4 +193,24 @@ export const collectionQueryBuilder = <T extends keyof Collections>(collection: 
 
 function singleQuote(value: unknown) {
   return `'${String(value).replace(/'/g, '\'\'')}'`
+}
+
+function quoteIdentifier(field: string | number | symbol, context: 'where' | 'order' | 'count') {
+  const stringField = String(field)
+  if (!stringField.match(/^[A-Za-z_][A-Za-z0-9_]*$/)) {
+    throw new TypeError(`Invalid ${context} field: ${stringField}`)
+  }
+  return `"${stringField}"`
+}
+
+function unquoteIdentifier(identifier: string) {
+  return identifier.slice(1, -1)
+}
+
+function toSafeOperator(operator: SQLOperator) {
+  const normalized = operator.toUpperCase() as SQLOperator
+  if (!SQL_OPERATORS.has(normalized)) {
+    throw new TypeError(`Invalid SQL operator: ${operator}`)
+  }
+  return normalized
 }

--- a/src/runtime/internal/query.ts
+++ b/src/runtime/internal/query.ts
@@ -10,6 +10,7 @@ const SQL_OPERATORS = new Set<SQLOperator>([
   '<',
   '<>',
   'IN',
+  'NOT IN',
   'BETWEEN',
   'NOT BETWEEN',
   'IS NULL',

--- a/src/types/query.ts
+++ b/src/types/query.ts
@@ -1,4 +1,4 @@
-export type SQLOperator = '=' | '>=' | '<=' | '>' | '<' | '<>' | 'IN' | 'BETWEEN' | 'NOT BETWEEN' | 'IS NULL' | 'IS NOT NULL' | 'LIKE' | 'NOT LIKE'
+export type SQLOperator = '=' | '>=' | '<=' | '>' | '<' | '<>' | 'IN' | 'NOT IN' | 'BETWEEN' | 'NOT BETWEEN' | 'IS NULL' | 'IS NOT NULL' | 'LIKE' | 'NOT LIKE'
 
 export type QueryGroupFunction<T> = (group: CollectionQueryGroup<T>) => CollectionQueryGroup<T>
 

--- a/test/unit/collectionQueryBuilder.test.ts
+++ b/test/unit/collectionQueryBuilder.test.ts
@@ -180,4 +180,14 @@ describe('collectionQueryBuilder', () => {
       'SELECT * FROM _articles WHERE ("path" = \'/blog/my-article\') ORDER BY stem ASC',
     )
   })
+
+  it('rejects unsafe where field names', () => {
+    const query = collectionQueryBuilder(mockCollection, mockFetch)
+    expect(() => query.where('title" DESC; DROP TABLE users; --', '=', 'x')).toThrow('Invalid where field')
+  })
+
+  it('rejects unsafe order field names', () => {
+    const query = collectionQueryBuilder(mockCollection, mockFetch)
+    expect(() => query.order('date" DESC, (SELECT 1)--' as never, 'ASC')).toThrow('Invalid order field')
+  })
 })

--- a/test/unit/collectionQueryBuilder.test.ts
+++ b/test/unit/collectionQueryBuilder.test.ts
@@ -59,6 +59,18 @@ describe('collectionQueryBuilder', () => {
     )
   })
 
+  it('builds query with NOT IN operator', async () => {
+    const query = collectionQueryBuilder(mockCollection, mockFetch)
+    await query
+      .where('category', 'NOT IN', ['news', 'tech'])
+      .all()
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'articles',
+      'SELECT * FROM _articles WHERE ("category" NOT IN (\'news\', \'tech\')) ORDER BY stem ASC',
+    )
+  })
+
   it('builds query with BETWEEN operator', async () => {
     const query = collectionQueryBuilder(mockCollection, mockFetch)
     await query


### PR DESCRIPTION
### Motivation
- A chainable API forwarded caller-controlled `field`, `operator`, and `value` into SQL fragments, creating an SQL injection vector when used by `queryCollectionNavigation`/`queryCollectionItemSurroundings`.
- The intent is to stop raw identifiers and operators from being concatenated into SQL while preserving the existing query building semantics.

### Description
- Add an operator allowlist `SQL_OPERATORS` and `toSafeOperator` to validate and normalize `where(...)` operators before SQL construction in `src/runtime/internal/query.ts`.
- Add strict identifier validation with `quoteIdentifier`/`unquoteIdentifier` and apply it to `where`, `order`, and `count` code paths so only simple alphanumeric/underscore identifiers are accepted and quoted.
- Normalize order direction to only `ASC` or `DESC` before appending to `ORDER BY`, and keep existing safe value quoting via `singleQuote` for literals.
- Add unit assertions to `test/unit/collectionQueryBuilder.test.ts` that expect unsafe `where` and `order` field names to throw.

### Testing
- Ran `pnpm -s vitest run test/unit/collectionQueryBuilder.test.ts test/unit/assertSafeQuery.test.ts` which failed to start because the project `tsconfig.json` extends a missing `./.nuxt/tsconfig.json`, causing Vitest/Vite to error before tests executed.
- New unit tests were added (`test/unit/collectionQueryBuilder.test.ts`) and committed, but the CI/local test run could not complete due to the TypeScript config resolution error described above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8a397f3088324b43876a477dacb57)